### PR TITLE
Implement patient/procedure/visit dialogs

### DIFF
--- a/na4shtab.PatientApp/ViewModels/PatientsViewModel.cs
+++ b/na4shtab.PatientApp/ViewModels/PatientsViewModel.cs
@@ -7,6 +7,9 @@ using System.Reactive.Linq;
 using System.Threading.Tasks;
 using na4shtab.PatientApp.Models;
 using na4shtab.PatientApp.Services;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
 
 namespace na4shtab.PatientApp.ViewModels
 {
@@ -61,16 +64,30 @@ namespace na4shtab.PatientApp.ViewModels
                 Patients.Add(p);
         }
 
-        private Task AddPatientAsync()
+        private async Task AddPatientAsync()
         {
-            // TODO: открыть диалог PatientEditViewModel(null)
-            return Task.CompletedTask;
+            var vm = new PatientEditViewModel();
+            var win = new Views.PatientEditWindow { DataContext = vm };
+            await win.ShowDialog(GetMainWindow());
+            await LoadPatientsAsync();
         }
 
-        private Task EditPatientAsync()
+        private async Task EditPatientAsync()
         {
-            // TODO: открыть диалог PatientEditViewModel(SelectedPatient)
-            return Task.CompletedTask;
+            if (SelectedPatient == null)
+                return;
+
+            var vm = new PatientEditViewModel(SelectedPatient);
+            var win = new Views.PatientEditWindow { DataContext = vm };
+            await win.ShowDialog(GetMainWindow());
+            await LoadPatientsAsync();
+        }
+
+        private static Avalonia.Controls.Window? GetMainWindow()
+        {
+            if (Avalonia.Application.Current?.ApplicationLifetime is Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop)
+                return desktop.MainWindow;
+            return null;
         }
 
         private async Task DeletePatientAsync()

--- a/na4shtab.PatientApp/ViewModels/ProcedureEditViewModel.cs
+++ b/na4shtab.PatientApp/ViewModels/ProcedureEditViewModel.cs
@@ -1,0 +1,83 @@
+using ReactiveUI;
+using Splat;
+using System.ComponentModel.DataAnnotations;
+using System.Reactive;
+using System.Threading.Tasks;
+using na4shtab.PatientApp.Models;
+using na4shtab.PatientApp.Services;
+
+namespace na4shtab.PatientApp.ViewModels;
+
+public class ProcedureEditViewModel : ViewModelBase
+{
+    private readonly IProcedureService _procedureService;
+    private readonly bool _isNew;
+
+    public int Id { get; }
+
+    private string _name = string.Empty;
+    [Required]
+    public string Name
+    {
+        get => _name;
+        set => this.RaiseAndSetIfChanged(ref _name, value);
+    }
+
+    private string _description = string.Empty;
+    public string Description
+    {
+        get => _description;
+        set => this.RaiseAndSetIfChanged(ref _description, value);
+    }
+
+    private decimal _cost;
+    public decimal Cost
+    {
+        get => _cost;
+        set => this.RaiseAndSetIfChanged(ref _cost, value);
+    }
+
+    public ReactiveCommand<Unit, Unit> SaveCommand { get; }
+    public ReactiveCommand<Unit, Unit> CancelCommand { get; }
+
+    public ProcedureEditViewModel(Procedure? procedure = null)
+    {
+        _procedureService = Locator.Current.GetService<IProcedureService>();
+
+        if (procedure == null)
+        {
+            _isNew = true;
+            Id = 0;
+        }
+        else
+        {
+            _isNew = false;
+            Id = procedure.Id;
+            Name = procedure.Name;
+            Description = procedure.Description;
+            Cost = procedure.Cost;
+        }
+
+        var canSave = this.WhenAnyValue(x => x.Name,
+                                        name => !string.IsNullOrWhiteSpace(name));
+
+        SaveCommand = ReactiveCommand.CreateFromTask(SaveAsync, canSave);
+        CancelCommand = ReactiveCommand.Create(() => { });
+    }
+
+    private async Task SaveAsync()
+    {
+        var model = new Procedure
+        {
+            Id = this.Id,
+            Name = this.Name,
+            Description = this.Description,
+            Cost = this.Cost
+        };
+
+        if (_isNew)
+            await _procedureService.AddAsync(model);
+        else
+            await _procedureService.UpdateAsync(model);
+    }
+}

--- a/na4shtab.PatientApp/ViewModels/ProcedureListViewModel.cs
+++ b/na4shtab.PatientApp/ViewModels/ProcedureListViewModel.cs
@@ -7,6 +7,9 @@ using ReactiveUI;
 using Splat;
 using na4shtab.PatientApp.Models;
 using na4shtab.PatientApp.Services;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
 
 namespace na4shtab.PatientApp.ViewModels;
 
@@ -61,16 +64,30 @@ public class ProcedureListViewModel : ViewModelBase
             Procedures.Add(p);
     }
 
-    private Task AddProcedureAsync()
+    private async Task AddProcedureAsync()
     {
-        // TODO: open ProcedureEdit dialog
-        return Task.CompletedTask;
+        var vm = new ProcedureEditViewModel();
+        var win = new Views.ProcedureEditWindow { DataContext = vm };
+        await win.ShowDialog(GetMainWindow());
+        await LoadProceduresAsync();
     }
 
-    private Task EditProcedureAsync()
+    private async Task EditProcedureAsync()
     {
-        // TODO: open ProcedureEdit dialog
-        return Task.CompletedTask;
+        if (SelectedProcedure == null)
+            return;
+
+        var vm = new ProcedureEditViewModel(SelectedProcedure);
+        var win = new Views.ProcedureEditWindow { DataContext = vm };
+        await win.ShowDialog(GetMainWindow());
+        await LoadProceduresAsync();
+    }
+
+    private static Avalonia.Controls.Window? GetMainWindow()
+    {
+        if (Avalonia.Application.Current?.ApplicationLifetime is Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop)
+            return desktop.MainWindow;
+        return null;
     }
 
     private async Task DeleteProcedureAsync()

--- a/na4shtab.PatientApp/ViewModels/VisitListViewModel.cs
+++ b/na4shtab.PatientApp/ViewModels/VisitListViewModel.cs
@@ -7,6 +7,9 @@ using System.Reactive.Linq;
 using System.Threading.Tasks;
 using na4shtab.PatientApp.Models;
 using na4shtab.PatientApp.Services;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
 
 namespace na4shtab.PatientApp.ViewModels
 {
@@ -61,16 +64,30 @@ namespace na4shtab.PatientApp.ViewModels
                 Visits.Add(v);
         }
 
-        private Task AddVisitAsync()
+        private async Task AddVisitAsync()
         {
-            // TODO: открыть диалог VisitEditViewModel(null)
-            return Task.CompletedTask;
+            var vm = new VisitEditViewModel(null, PatientFilterId ?? 0);
+            var win = new Views.VisitEditWindow { DataContext = vm };
+            await win.ShowDialog(GetMainWindow());
+            await LoadVisitsAsync();
         }
 
-        private Task EditVisitAsync()
+        private async Task EditVisitAsync()
         {
-            // TODO: открыть диалог VisitEditViewModel(SelectedVisit)
-            return Task.CompletedTask;
+            if (SelectedVisit == null)
+                return;
+
+            var vm = new VisitEditViewModel(SelectedVisit, SelectedVisit.PatientId);
+            var win = new Views.VisitEditWindow { DataContext = vm };
+            await win.ShowDialog(GetMainWindow());
+            await LoadVisitsAsync();
+        }
+
+        private static Avalonia.Controls.Window? GetMainWindow()
+        {
+            if (Avalonia.Application.Current?.ApplicationLifetime is Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop)
+                return desktop.MainWindow;
+            return null;
         }
 
         private async Task DeleteVisitAsync()

--- a/na4shtab.PatientApp/Views/PatientEditWindow.axaml
+++ b/na4shtab.PatientApp/Views/PatientEditWindow.axaml
@@ -1,0 +1,20 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:na4shtab.PatientApp.ViewModels"
+        x:Class="na4shtab.PatientApp.Views.PatientEditWindow"
+        Width="400" Height="250"
+        WindowStartupLocation="CenterOwner"
+        x:DataType="vm:PatientEditViewModel">
+    <StackPanel Margin="10" Spacing="4">
+        <TextBlock Text="ФИО"/>
+        <TextBox Text="{Binding FullName}"/>
+        <TextBlock Text="Дата рождения" Margin="0,8,0,0"/>
+        <DatePicker SelectedDate="{Binding BirthDate}"/>
+        <TextBlock Text="Контакты" Margin="0,8,0,0"/>
+        <TextBox Text="{Binding ContactInfo}"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0" Spacing="4">
+            <Button Content="Отмена" Command="{Binding CancelCommand}" Width="80"/>
+            <Button Content="Сохранить" Command="{Binding SaveCommand}" Width="100"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/na4shtab.PatientApp/Views/PatientEditWindow.axaml.cs
+++ b/na4shtab.PatientApp/Views/PatientEditWindow.axaml.cs
@@ -1,0 +1,23 @@
+using Avalonia.Controls;
+using na4shtab.PatientApp.ViewModels;
+using System;
+
+namespace na4shtab.PatientApp.Views;
+
+public partial class PatientEditWindow : Window
+{
+    public PatientEditWindow()
+    {
+        InitializeComponent();
+        this.DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        if (DataContext is PatientEditViewModel vm)
+        {
+            vm.SaveCommand.Subscribe(_ => Close(true));
+            vm.CancelCommand.Subscribe(_ => Close(false));
+        }
+    }
+}

--- a/na4shtab.PatientApp/Views/ProcedureEditWindow.axaml
+++ b/na4shtab.PatientApp/Views/ProcedureEditWindow.axaml
@@ -1,0 +1,20 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:na4shtab.PatientApp.ViewModels"
+        x:Class="na4shtab.PatientApp.Views.ProcedureEditWindow"
+        Width="400" Height="250"
+        WindowStartupLocation="CenterOwner"
+        x:DataType="vm:ProcedureEditViewModel">
+    <StackPanel Margin="10" Spacing="4">
+        <TextBlock Text="Название"/>
+        <TextBox Text="{Binding Name}"/>
+        <TextBlock Text="Описание" Margin="0,8,0,0"/>
+        <TextBox Text="{Binding Description}"/>
+        <TextBlock Text="Стоимость" Margin="0,8,0,0"/>
+        <TextBox Text="{Binding Cost}"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0" Spacing="4">
+            <Button Content="Отмена" Command="{Binding CancelCommand}" Width="80"/>
+            <Button Content="Сохранить" Command="{Binding SaveCommand}" Width="100"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/na4shtab.PatientApp/Views/ProcedureEditWindow.axaml.cs
+++ b/na4shtab.PatientApp/Views/ProcedureEditWindow.axaml.cs
@@ -1,0 +1,23 @@
+using Avalonia.Controls;
+using na4shtab.PatientApp.ViewModels;
+using System;
+
+namespace na4shtab.PatientApp.Views;
+
+public partial class ProcedureEditWindow : Window
+{
+    public ProcedureEditWindow()
+    {
+        InitializeComponent();
+        this.DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        if (DataContext is ProcedureEditViewModel vm)
+        {
+            vm.SaveCommand.Subscribe(_ => Close(true));
+            vm.CancelCommand.Subscribe(_ => Close(false));
+        }
+    }
+}

--- a/na4shtab.PatientApp/Views/VisitEditWindow.axaml
+++ b/na4shtab.PatientApp/Views/VisitEditWindow.axaml
@@ -1,0 +1,53 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:na4shtab.PatientApp.ViewModels"
+        xmlns:m="clr-namespace:na4shtab.PatientApp.Models"
+        xmlns:dg="clr-namespace:Avalonia.Controls;assembly=Avalonia.Controls.DataGrid"
+        x:Class="na4shtab.PatientApp.Views.VisitEditWindow"
+        Width="600" Height="400"
+        WindowStartupLocation="CenterOwner"
+        x:CompileBindings="False">
+    <StackPanel Margin="10" Spacing="4">
+        <TextBlock Text="Дата"/>
+        <DatePicker SelectedDate="{Binding Date}"/>
+        <StackPanel Orientation="Horizontal" Margin="0,8,0,0" Spacing="8">
+            <StackPanel Width="250">
+                <TextBlock Text="Доступные процедуры"/>
+                <dg:DataGrid ItemsSource="{Binding AvailableProcedures}"
+                             AutoGenerateColumns="False" Height="150">
+                    <dg:DataGrid.Columns>
+                        <dg:DataGridTextColumn Header="Название" Binding="{Binding Name}" Width="*"/>
+                        <dg:DataGridTemplateColumn Header="">
+                            <dg:DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <Button Content="+" Command="{Binding DataContext.ToggleProcedureCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="{Binding}"/>
+                                </DataTemplate>
+                            </dg:DataGridTemplateColumn.CellTemplate>
+                        </dg:DataGridTemplateColumn>
+                    </dg:DataGrid.Columns>
+                </dg:DataGrid>
+            </StackPanel>
+            <StackPanel Width="250">
+                <TextBlock Text="Выбранные процедуры"/>
+                <dg:DataGrid ItemsSource="{Binding SelectedProcedures}"
+                             AutoGenerateColumns="False" Height="150">
+                    <dg:DataGrid.Columns>
+                        <dg:DataGridTextColumn Header="Название" Binding="{Binding Name}" Width="*"/>
+                        <dg:DataGridTemplateColumn Header="">
+                            <dg:DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <Button Content="-" Command="{Binding DataContext.ToggleProcedureCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="{Binding}"/>
+                                </DataTemplate>
+                            </dg:DataGridTemplateColumn.CellTemplate>
+                        </dg:DataGridTemplateColumn>
+                    </dg:DataGrid.Columns>
+                </dg:DataGrid>
+            </StackPanel>
+        </StackPanel>
+        <TextBlock Margin="0,8,0,0" Text="{Binding TotalCost, StringFormat='Итого: {0}'}"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0" Spacing="4">
+            <Button Content="Отмена" Command="{Binding CancelCommand}" Width="80"/>
+            <Button Content="Сохранить" Command="{Binding SaveCommand}" Width="100"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/na4shtab.PatientApp/Views/VisitEditWindow.axaml.cs
+++ b/na4shtab.PatientApp/Views/VisitEditWindow.axaml.cs
@@ -1,0 +1,23 @@
+using Avalonia.Controls;
+using na4shtab.PatientApp.ViewModels;
+using System;
+
+namespace na4shtab.PatientApp.Views;
+
+public partial class VisitEditWindow : Window
+{
+    public VisitEditWindow()
+    {
+        InitializeComponent();
+        this.DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        if (DataContext is VisitEditViewModel vm)
+        {
+            vm.SaveCommand.Subscribe(_ => Close(true));
+            vm.CancelCommand.Subscribe(_ => Close(false));
+        }
+    }
+}

--- a/na4shtab.PatientApp/Views/VisitListView.axaml
+++ b/na4shtab.PatientApp/Views/VisitListView.axaml
@@ -1,0 +1,27 @@
+<UserControl
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:vm="clr-namespace:na4shtab.PatientApp.ViewModels"
+    xmlns:dg="clr-namespace:Avalonia.Controls;assembly=Avalonia.Controls.DataGrid"
+    x:Class="na4shtab.PatientApp.Views.VisitListView"
+    x:DataType="vm:VisitListViewModel">
+    <UserControl.DataContext>
+        <vm:VisitListViewModel/>
+    </UserControl.DataContext>
+    <DockPanel>
+        <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="4">
+            <Button Content="Добавить" Command="{Binding AddVisitCommand}" Margin="2"/>
+            <Button Content="Изменить" Command="{Binding EditVisitCommand}" Margin="2"/>
+            <Button Content="Удалить" Command="{Binding DeleteVisitCommand}" Margin="2"/>
+        </StackPanel>
+        <dg:DataGrid ItemsSource="{Binding Visits}"
+                     SelectedItem="{Binding SelectedVisit}"
+                     AutoGenerateColumns="False" Margin="4">
+            <dg:DataGrid.Columns>
+                <dg:DataGridTextColumn Header="Дата" Binding="{Binding Date, StringFormat='dd.MM.yyyy'}" Width="150"/>
+                <dg:DataGridTextColumn Header="Пациент" Binding="{Binding Patient.FullName}" Width="2*"/>
+                <dg:DataGridTextColumn Header="Стоимость" Binding="{Binding TotalCost}" Width="150"/>
+            </dg:DataGrid.Columns>
+        </dg:DataGrid>
+    </DockPanel>
+</UserControl>

--- a/na4shtab.PatientApp/Views/VisitListView.axaml.cs
+++ b/na4shtab.PatientApp/Views/VisitListView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace na4shtab.PatientApp.Views;
+
+public partial class VisitListView : UserControl
+{
+    public VisitListView()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
## Summary
- implement dialog windows for editing patients, procedures, and visits
- hook up PatientList, ProcedureList and VisitList view models to open dialog windows
- add minimal views for visits and edit windows

## Testing
- `dotnet build na4shtab.PatientApp.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688b022a36208323a233c09ed6b71d94